### PR TITLE
Problem: can't have + in Python version string

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -12,7 +12,7 @@ if [ $2 = 'python' ]
 then
     if [ ${3-x} ];
     then
-        export VERSION=$VERSION+1.$3
+        export VERSION=$VERSION.dev.1
     fi
     docker run --rm -v ${PWD}:/local swaggerapi/swagger-codegen-cli generate \
         -i /local/api.json \


### PR DESCRIPTION
Solution: use .dev.1 for now

In the future this string will contain the number of commits since the tag

re: #4694
https://pulp.plan.io/issues/4694