### PR TITLE
Problem: the prerelease version always ends in .dev.1

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -8,12 +8,13 @@ curl -o api.json http://localhost:24817/pulp/api/v3/docs/api.json?plugin=$1
 # Get the version of the pulpcore or plugin as reported by status API
 export VERSION=$(http :24817/pulp/api/v3/status/ | jq --arg plugin $1 -r '.versions[] | select(.component == $plugin) | .version')
 
+if [ ${3-x} ];
+then
+    export VERSION=$VERSION.dev.$3
+fi
+
 if [ $2 = 'python' ]
 then
-    if [ ${3-x} ];
-    then
-        export VERSION=$VERSION.dev.1
-    fi
     docker run --rm -v ${PWD}:/local swaggerapi/swagger-codegen-cli generate \
         -i /local/api.json \
         -l python \
@@ -33,10 +34,6 @@ then
 fi
 if [ $2 = 'ruby' ]
 then
-    if [ ${3-x} ];
-    then
-        export VERSION=$VERSION-$3
-    fi
     docker run --rm -v ${PWD}:/local swaggerapi/swagger-codegen-cli generate \
         -i /local/api.json \
         -l ruby \


### PR DESCRIPTION
Solution: change the 1 to a parameter passed in by user

re: #4694
https://pulp.plan.io/issues/4694