### PR TITLE
Problem: user can't specify a version for generated bindings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,10 +15,10 @@ Requirements
 Generating bindings
 -------------------
 
-The ``generate.sh`` script takes three positional arguments: module name, language, and commit
-hash. When a commit hash is provided, it is appended to the version string. This denotes a
-pre-release build. The following commands should be used to generate Python bindings for
-``pulpcore``:
+The ``generate.sh`` script takes three positional arguments: module name, language, and version.
+When the optional version parameter is provided, it is used as the version string. When it is not
+provided, the version reported by Pulp's status API is used. The following commands should be used
+to generate Python bindings for ``pulpcore``:
 
 .. code-block:: bash
 
@@ -36,8 +36,8 @@ This command will generate a Ruby Gem inside ``pulp_rpm-client`` directory.
 
 The packages generated will have the same version as what is reported by the status API.
 
-This command will generate a Ruby Gem with 'fe3n1a' appended to the version string.
+This command will generate a Ruby Gem with '3.0.0rc1.dev.10' version.
 
 .. code-block:: bash
 
-    sudo ./generate.sh pulp_rpm ruby fe3n1a
+    sudo ./generate.sh pulp_rpm ruby 3.0.0rc1.dev.10

--- a/generate.sh
+++ b/generate.sh
@@ -6,11 +6,12 @@ fi
 # Download the schema
 curl -o api.json http://localhost:24817/pulp/api/v3/docs/api.json?plugin=$1
 # Get the version of the pulpcore or plugin as reported by status API
-export VERSION=$(http :24817/pulp/api/v3/status/ | jq --arg plugin $1 -r '.versions[] | select(.component == $plugin) | .version')
 
 if [ ${3-x} ];
 then
-    export VERSION=$VERSION.dev.$3
+    export VERSION=$3
+else
+    export VERSION=$(http :24817/pulp/api/v3/status/ | jq --arg plugin $1 -r '.versions[] | select(.component == $plugin) | .version')
 fi
 
 if [ $2 = 'python' ]


### PR DESCRIPTION
Solution: allow user to specify the full version string

This patch updates generate.sh to accept an optional third parameter. This parameter represents the full
version string that should be used when generating the client library.

re: #4694
https://pulp.plan.io/issues/4694